### PR TITLE
Simple beam search

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ import dolphin
 waveform = dolphin.load_audio("audio.wav")
 model = dolphin.load_model("small", "/data/models/dolphin", "cuda")
 result = model(waveform)
+# Specify language
+result = model(waveform, lang_sym="zh")
 # Specify language and region
 result = model(waveform, lang_sym="zh", region_sym="CN")
 print(result.text)

--- a/dolphin/beam_search.py
+++ b/dolphin/beam_search.py
@@ -72,7 +72,7 @@ class SimpleBeamSearch(BatchBeamSearch):
                 i, maxlen, minlen, maxlenratio, best, ended_hyps
             )
             # simple beam search stop condition
-            if len(ended_hyps) > self.beam_size:
+            if len(ended_hyps) >= self.beam_size:
                 logger.info(f"end detected for beam sizs: {self.beam_size}")
                 break 
             # end detection

--- a/dolphin/beam_search.py
+++ b/dolphin/beam_search.py
@@ -1,6 +1,7 @@
 import torch
 from typing import Any, Dict, List, NamedTuple, Tuple, Union
 from espnet.nets.beam_search import BeamSearch, Hypothesis
+from espnet.nets.batch_beam_search import BatchBeamSearch
 from espnet.nets.e2e_asr_common import end_detect
 
 import logging
@@ -8,7 +9,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class SimpleBeamSearch(BeamSearch):
+class SimpleBeamSearch(BatchBeamSearch):
     """Simple beam search decoder.
     Just when the hyps equals to beam size, it will stop decoding."""
         

--- a/dolphin/beam_search.py
+++ b/dolphin/beam_search.py
@@ -1,0 +1,133 @@
+import torch
+from typing import Any, Dict, List, NamedTuple, Tuple, Union
+from espnet.nets.beam_search import BeamSearch, Hypothesis
+from espnet.nets.e2e_asr_common import end_detect
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class SimpleBeamSearch(BeamSearch):
+    """Simple beam search decoder.
+    Just when the hyps equals to beam size, it will stop decoding."""
+        
+    def forward(
+        self,
+        x: torch.Tensor,
+        maxlenratio: float = 0.0,
+        minlenratio: float = 0.0,
+        pre_x: torch.Tensor = None,
+    ) -> List[Hypothesis]:
+        """Perform beam search.
+
+        Args:
+            x (torch.Tensor): Encoded speech feature (T, D)
+            maxlenratio (float): Input length ratio to obtain max output length.
+                If maxlenratio=0.0 (default), it uses a end-detect function
+                to automatically find maximum hypothesis lengths
+                If maxlenratio<0.0, its absolute value is interpreted
+                as a constant max output length.
+            minlenratio (float): Input length ratio to obtain min output length.
+                If minlenratio<0.0, its absolute value is interpreted
+                as a constant min output length.
+            pre_x (torch.Tensor): Encoded speech feature for sequential attn (T, D)
+                Sequential attn computes attn first on pre_x then on x,
+                thereby attending to two sources in sequence.
+
+        Returns:
+            list[Hypothesis]: N-best decoding results
+
+        """
+        logger.info("Simple beam search decoding...")
+        # set length bounds
+        if pre_x is not None:
+            inp = pre_x
+        else:
+            inp = x
+        if maxlenratio == 0:
+            maxlen = inp.shape[0]
+        elif maxlenratio < 0:
+            maxlen = -1 * int(maxlenratio)
+        else:
+            maxlen = max(1, int(maxlenratio * inp.size(0)))
+
+        if minlenratio < 0:
+            minlen = -1 * int(minlenratio)
+        else:
+            minlen = int(minlenratio * inp.size(0))
+        logger.info("decoder input length: " + str(inp.shape[0]))
+        logger.info("max output length: " + str(maxlen))
+        logger.info("min output length: " + str(minlen))
+
+        # main loop of prefix search
+        running_hyps = self.init_hyp(x if pre_x is None else pre_x)
+        ended_hyps = []
+        for i in range(maxlen):
+            logger.debug("position " + str(i))
+            best = self.search(running_hyps, x, pre_x=pre_x)
+            # post process of one iteration
+            running_hyps = self.post_process(
+                i, maxlen, minlen, maxlenratio, best, ended_hyps
+            )
+            # simple beam search stop condition
+            if len(ended_hyps) > self.beam_size:
+                logger.info(f"end detected for beam sizs: {self.beam_size}")
+                break 
+            # end detection
+            if maxlenratio == 0.0 and end_detect([h.asdict() for h in ended_hyps], i):
+                logger.info(f"end detected at {i}")
+                break
+            if len(running_hyps) == 0:
+                logger.info("no hypothesis. Finish decoding.")
+                break
+            else:
+                logger.debug(f"remained hypotheses: {len(running_hyps)}")
+
+        if self.normalize_length:
+            # Note (Jinchuan): -1 since hyp starts with <sos> and
+            # initially has score of 0.0
+            nbest_hyps = sorted(
+                ended_hyps, key=lambda x: x.score / (len(x.yseq) - 1), reverse=True
+            )
+        else:
+            nbest_hyps = sorted(ended_hyps, key=lambda x: x.score, reverse=True)
+
+        # check the number of hypotheses reaching to eos
+        if len(nbest_hyps) == 0:
+            logger.warning(
+                "there is no N-best results, perform recognition "
+                "again with smaller minlenratio."
+            )
+            return (
+                []
+                if minlenratio < 0.1
+                else self.forward(x, maxlenratio, max(0.0, minlenratio - 0.1))
+            )
+
+        # report the best result
+        best = nbest_hyps[0]
+        for k, v in best.scores.items():
+            logger.info(
+                f"{v:6.2f} * {self.weights[k]:3} = {v * self.weights[k]:6.2f} for {k}"
+            )
+        logger.info(f"total log probability: {best.score:.2f}")
+        logger.info(f"normalized log probability: {best.score / len(best.yseq):.2f}")
+        logger.info(f"total number of ended hypotheses: {len(nbest_hyps)}")
+        if self.token_list is not None:
+            logger.info(
+                "best hypo: "
+                + "".join([self.token_list[x] for x in best.yseq[1:-1]])
+                + "\n"
+            )
+        if best.yseq[1:-1].shape[0] == maxlen:
+            logger.warning(
+                "best hypo length: {} == max output length: {}".format(
+                    best.yseq[1:-1].shape[0], maxlen
+                )
+            )
+            logger.warning(
+                "decoding may be stopped by the max output length limitation, "
+                + "please consider to increase the maxlenratio."
+            )
+        return nbest_hyps

--- a/dolphin/model.py
+++ b/dolphin/model.py
@@ -18,13 +18,13 @@ from espnet2.tasks.s2t import S2TTask
 from espnet2.torch_utils.device_funcs import to_device
 from espnet.nets.batch_beam_search import BatchBeamSearch
 from espnet2.train.abs_espnet_model import AbsESPnetModel
-from espnet.nets.beam_search import BeamSearch, Hypothesis
 from espnet.nets.scorer_interface import BatchScorerInterface
 from espnet.nets.scorers.length_bonus import LengthBonus
 from espnet2.text.build_tokenizer import build_tokenizer
 from espnet2.text.token_id_converter import TokenIDConverter
 from espnet2.bin.s2t_inference import Speech2Text, ListOfHypothesis
 from dolphin.scorefilter import DolphinScoreFilter
+from dolphin.beam_search import SimpleBeamSearch
 
 from .constants import (SPEECH_LENGTH, SAMPLE_RATE, FIRST_TIME_SYMBOL, LAST_TIME_SYMBOL, NOTIME_SYMBOL,
                         FIRST_LANG_SYMBOL, LAST_LANG_SYMBOL, FIRST_REGION_SYMBOL, LAST_REGION_SYMBOL)
@@ -128,7 +128,7 @@ class DolphinSpeech2Text(Speech2Text):
             scorefilter=1.0,
         )
 
-        beam_search = BeamSearch(
+        beam_search = SimpleBeamSearch(
             beam_size=beam_size,
             weights=weights,
             scorers=scorers,

--- a/dolphin/model.py
+++ b/dolphin/model.py
@@ -69,8 +69,7 @@ class DolphinSpeech2Text(Speech2Text):
         quantize_modules: List[str] = ["Linear"],
         quantize_dtype: str = "qint8",
         task_sym: str = "<asr>",
-        predict_time: bool = True,
-        beam_search_type: str = "raw"
+        predict_time: bool = True
     ):
 
         qconfig_spec = set([getattr(torch.nn, q) for q in quantize_modules])
@@ -129,12 +128,8 @@ class DolphinSpeech2Text(Speech2Text):
             length_bonus=penalty,
             scorefilter=1.0,
         )
-        if beam_search_type == "raw":
-            beam_search_class = BeamSearch
-        elif beam_search_type == "simple":
-            beam_search_class = SimpleBeamSearch
             
-        beam_search = beam_search_class(
+        beam_search = SimpleBeamSearch(
             beam_size=beam_size,
             weights=weights,
             scorers=scorers,
@@ -153,10 +148,7 @@ class DolphinSpeech2Text(Speech2Text):
                 if not isinstance(v, BatchScorerInterface)
             ]
             if len(non_batch) == 0:
-                if beam_search_type == "simple":
-                    beam_search.__class__ = SimpleBeamSearch
-                else:
-                    beam_search.__class__ = BatchBeamSearch
+                beam_search.__class__ = SimpleBeamSearch
                 logger.info("BatchBeamSearch implementation is selected.")
             else:
                 logger.warning(


### PR DESCRIPTION
**What Changed**

add a new beam search breaking condition as follow

```python
# simple beam search stop condition
if len(ended_hyps) >= self.beam_size:
    logger.info(f"end detected for beam sizs: {self.beam_size}")
    break 
```

**Testing Conditions:**

A test audio file ([zh.mp3](https://huggingface.co/FunAudioLLM/SenseVoiceSmall/blob/main/example/zh.mp3)) with a duration of 5.6 seconds was used. The decoding process was run 100 times, with a beam size of 5 and padding_speech=False. The device used was a MacBook Pro.

**Results:**

The time cost for the two methods is as follows:

| BeamSearch Methods   | Cost Time(s) |  RTF    |
| -------------------- | ------------ | ---- |
| Original from espnet |      984.95        |   1.76   |
| Simplified           | 84           |   0.15   |


**Performance Evaluation:**

The performance(WER) of the method was tested and showed no degradation, while the speed improved by 11x.

